### PR TITLE
ver4.8.a

### DIFF
--- a/visualizer.html
+++ b/visualizer.html
@@ -524,7 +524,7 @@ function doaction(drawflag) {
 					actionfield[x][y] = 1;
 					for (var k = enenum ; k < enenum + 3 ; k++) {
 						if (x == px[k] && y == py[k]) {
-							pcure[k] = 17;
+							pcure[k] = 18;
 							px[k] = pbx[k];
 							py[k] = pby[k];
 							phidden[k] = 0;


### PR DESCRIPTION
## 療治ターンを誤っていた問題を修正

下記対戦で占領数エラーが出ていました。

https://arena.ai-comp.net/contests/1/battle_results/120505
（現在公式ビジュアライザでも同様の表示エラーになります）

jsonファイルから対戦を公式managerで再現した結果、
療治ターンが1つ少ないようです。